### PR TITLE
Add tab navigation with side menu

### DIFF
--- a/babynanny/ContentView.swift
+++ b/babynanny/ContentView.swift
@@ -8,14 +8,85 @@
 import SwiftUI
 
 struct ContentView: View {
+    @State private var selectedTab: Tab = .home
+    @State private var isMenuVisible = false
+    @State private var showSettings = false
+
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        NavigationStack {
+            ZStack(alignment: .leading) {
+                TabView(selection: $selectedTab) {
+                    HomeView()
+                        .tag(Tab.home)
+                        .tabItem {
+                            Label("Home", systemImage: Tab.home.icon)
+                        }
+
+                    StatsView()
+                        .tag(Tab.stats)
+                        .tabItem {
+                            Label("Stats", systemImage: Tab.stats.icon)
+                        }
+                }
+                .disabled(isMenuVisible)
+
+                if isMenuVisible {
+                    Color.black.opacity(0.25)
+                        .ignoresSafeArea()
+                        .onTapGesture {
+                            withAnimation(.easeInOut) {
+                                isMenuVisible = false
+                            }
+                        }
+
+                    SideMenu {
+                        withAnimation(.easeInOut) {
+                            isMenuVisible = false
+                            showSettings = true
+                        }
+                    }
+                    .transition(.move(edge: .leading))
+                }
+            }
+            .navigationTitle(selectedTab.title)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button {
+                        withAnimation(.easeInOut) {
+                            isMenuVisible.toggle()
+                        }
+                    } label: {
+                        Image(systemName: "line.3.horizontal")
+                    }
+                }
+            }
+            .navigationDestination(isPresented: $showSettings) {
+                SettingsView()
+            }
         }
-        .padding()
+    }
+}
+
+private enum Tab: Hashable {
+    case home
+    case stats
+
+    var title: String {
+        switch self {
+        case .home:
+            return "Home"
+        case .stats:
+            return "Stats"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .home:
+            return "house"
+        case .stats:
+            return "chart.bar"
+        }
     }
 }
 

--- a/babynanny/HomeView.swift
+++ b/babynanny/HomeView.swift
@@ -1,0 +1,35 @@
+//
+//  HomeView.swift
+//  babynanny
+//
+//  Created by OpenAI Assistant on 2024/10/07.
+//
+
+import SwiftUI
+
+struct HomeView: View {
+    var body: some View {
+        VStack(spacing: 24) {
+            Image(systemName: "house.fill")
+                .font(.system(size: 52))
+                .foregroundStyle(.accent)
+
+            VStack(spacing: 8) {
+                Text("Welcome Home")
+                    .font(.title)
+                    .fontWeight(.semibold)
+
+                Text("Here you can manage your daily nanny tasks and keep an eye on ongoing activities.")
+                    .multilineTextAlignment(.center)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
+        .background(Color(.systemGroupedBackground))
+    }
+}
+
+#Preview {
+    HomeView()
+}

--- a/babynanny/SettingsView.swift
+++ b/babynanny/SettingsView.swift
@@ -1,0 +1,53 @@
+//
+//  SettingsView.swift
+//  babynanny
+//
+//  Created by OpenAI Assistant on 2024/10/07.
+//
+
+import SwiftUI
+
+struct SettingsView: View {
+    var body: some View {
+        Form {
+            Section(header: Text("Profile")) {
+                HStack {
+                    Image(systemName: "person.circle.fill")
+                        .font(.largeTitle)
+                        .foregroundStyle(.accent)
+                    VStack(alignment: .leading) {
+                        Text("Caregiver Name")
+                            .font(.headline)
+                        Text("Edit your profile details")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+
+            Section(header: Text("Notifications")) {
+                Toggle(isOn: .constant(true)) {
+                    Text("Enable reminders")
+                }
+                .disabled(true)
+                .foregroundStyle(.secondary)
+            }
+
+            Section(header: Text("About")) {
+                HStack {
+                    Text("App Version")
+                    Spacer()
+                    Text("1.0")
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .navigationTitle("Settings")
+    }
+}
+
+#Preview {
+    NavigationStack {
+        SettingsView()
+    }
+}

--- a/babynanny/SideMenu.swift
+++ b/babynanny/SideMenu.swift
@@ -1,0 +1,43 @@
+//
+//  SideMenu.swift
+//  babynanny
+//
+//  Created by OpenAI Assistant on 2024/10/07.
+//
+
+import SwiftUI
+
+struct SideMenu: View {
+    let onSelectSettings: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 32) {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Nanny & Me")
+                    .font(.largeTitle)
+                    .fontWeight(.bold)
+                Text("Quick actions")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.top, 48)
+
+            Button(action: onSelectSettings) {
+                Label("Settings", systemImage: "gearshape.fill")
+                    .font(.headline)
+            }
+
+            Spacer()
+        }
+        .padding(.horizontal, 24)
+        .padding(.bottom, 32)
+        .frame(maxWidth: 260, alignment: .leading)
+        .frame(maxHeight: .infinity)
+        .background(.ultraThinMaterial)
+        .ignoresSafeArea()
+    }
+}
+
+#Preview {
+    SideMenu(onSelectSettings: {})
+}

--- a/babynanny/StatsView.swift
+++ b/babynanny/StatsView.swift
@@ -1,0 +1,35 @@
+//
+//  StatsView.swift
+//  babynanny
+//
+//  Created by OpenAI Assistant on 2024/10/07.
+//
+
+import SwiftUI
+
+struct StatsView: View {
+    var body: some View {
+        VStack(spacing: 24) {
+            Image(systemName: "chart.bar.fill")
+                .font(.system(size: 52))
+                .foregroundStyle(.accent)
+
+            VStack(spacing: 8) {
+                Text("Stats Overview")
+                    .font(.title)
+                    .fontWeight(.semibold)
+
+                Text("Track daily progress, sleep schedules, and feeding stats in one glance.")
+                    .multilineTextAlignment(.center)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
+        .background(Color(.systemGroupedBackground))
+    }
+}
+
+#Preview {
+    StatsView()
+}


### PR DESCRIPTION
## Summary
- replace the placeholder content view with a tab-based layout for Home and Stats
- add a slide-out menu with a Settings shortcut that opens a dedicated settings page
- create simple placeholder views for Home, Stats, and Settings content

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3d031e6548320aeb2664aba782db2