### PR TITLE
Replace deprecated accent style usages

### DIFF
--- a/babynanny/HomeView.swift
+++ b/babynanny/HomeView.swift
@@ -12,7 +12,7 @@ struct HomeView: View {
         VStack(spacing: 24) {
             Image(systemName: "house.fill")
                 .font(.system(size: 52))
-                .foregroundStyle(.accent)
+                .foregroundStyle(Color.accentColor)
 
             VStack(spacing: 8) {
                 Text("Welcome Home")

--- a/babynanny/SettingsView.swift
+++ b/babynanny/SettingsView.swift
@@ -14,7 +14,7 @@ struct SettingsView: View {
                 HStack {
                     Image(systemName: "person.circle.fill")
                         .font(.largeTitle)
-                        .foregroundStyle(.accent)
+                        .foregroundStyle(Color.accentColor)
                     VStack(alignment: .leading) {
                         Text("Caregiver Name")
                             .font(.headline)

--- a/babynanny/StatsView.swift
+++ b/babynanny/StatsView.swift
@@ -12,7 +12,7 @@ struct StatsView: View {
         VStack(spacing: 24) {
             Image(systemName: "chart.bar.fill")
                 .font(.system(size: 52))
-                .foregroundStyle(.accent)
+                .foregroundStyle(Color.accentColor)
 
             VStack(spacing: 8) {
                 Text("Stats Overview")


### PR DESCRIPTION
## Summary
- update SettingsView and StatsView to use `Color.accentColor` for foreground styling instead of the deprecated `.accent` API

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3d68145708320b5206cc1e15d28ad