### PR TITLE
Fix settings navigation destination placement

### DIFF
--- a/babynanny/ContentView.swift
+++ b/babynanny/ContentView.swift
@@ -41,9 +41,9 @@ struct ContentView: View {
                         }
                     }
                 }
-            }
-            .navigationDestination(isPresented: $showSettings) {
-                SettingsView()
+                .navigationDestination(isPresented: $showSettings) {
+                    SettingsView()
+                }
             }
 
             if isMenuVisible {


### PR DESCRIPTION
## Summary
- attach the Settings navigationDestination modifier directly to the content inside the NavigationStack
- ensure the SettingsView presentation binding is honored when toggled from the side menu

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3f3935a448320a734eacd33431d38