### PR TITLE
Make diaper logs instant and adjust labels

### DIFF
--- a/babynanny/HomeView.swift
+++ b/babynanny/HomeView.swift
@@ -205,7 +205,7 @@ private struct ActionCard: View {
                         .foregroundStyle(.secondary)
                 }
 
-                Button("Start") {
+                Button(category.startActionButtonTitle) {
                     onStart()
                 }
                 .buttonStyle(.bordered)
@@ -342,7 +342,7 @@ private struct ActionDetailSheet: View {
                 }
 
                 ToolbarItem(placement: .confirmationAction) {
-                    Button("Start") {
+                    Button(category.startActionButtonTitle) {
                         onStart(configuration)
                         dismiss()
                     }


### PR DESCRIPTION
## Summary
- treat diaper actions as instant logs, recording start and end simultaneously
- update diaper-related buttons to display “Log” and keep the sheet consistent
- rename the sleep detail description to remove the “Nap time” wording

## Testing
- not run (iOS project)

------
https://chatgpt.com/codex/tasks/task_e_68e41b073318832096dab399091a684d