### PR TITLE
Limit home recent activity list

### DIFF
--- a/babynanny/ActionLogViewModel.swift
+++ b/babynanny/ActionLogViewModel.swift
@@ -211,6 +211,19 @@ struct ProfileActionState: Codable {
         self.history = history
     }
 
+    func latestHistoryEntriesPerCategory() -> [BabyAction] {
+        var seenCategories = Set<BabyActionCategory>()
+        var uniqueEntries: [BabyAction] = []
+
+        for action in history {
+            guard !seenCategories.contains(action.category) else { continue }
+            seenCategories.insert(action.category)
+            uniqueEntries.append(action)
+        }
+
+        return uniqueEntries
+    }
+
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let rawActive = try container.decode([String: BabyAction].self, forKey: .activeActions)

--- a/babynanny/ContentView.swift
+++ b/babynanny/ContentView.swift
@@ -19,7 +19,7 @@ struct ContentView: View {
         ZStack(alignment: .leading) {
             NavigationStack {
                 TabView(selection: $selectedTab) {
-                    HomeView()
+                    HomeView(onShowAllLogs: { showAllLogs = true })
                         .tag(Tab.home)
                         .tabItem {
                             Label(L10n.Tab.home, systemImage: Tab.home.icon)

--- a/babynanny/HomeView.swift
+++ b/babynanny/HomeView.swift
@@ -11,9 +11,15 @@ struct HomeView: View {
     @EnvironmentObject private var profileStore: ProfileStore
     @EnvironmentObject private var actionStore: ActionLogStore
     @State private var presentedCategory: BabyActionCategory?
+    private let onShowAllLogs: () -> Void
+
+    init(onShowAllLogs: @escaping () -> Void = {}) {
+        self.onShowAllLogs = onShowAllLogs
+    }
 
     var body: some View {
         let state = currentState
+        let recentHistory = state.latestHistoryEntriesPerCategory()
 
         ScrollView {
             VStack(alignment: .leading, spacing: 24) {
@@ -31,13 +37,25 @@ struct HomeView: View {
                     }
                 }
 
-                if !state.history.isEmpty {
+                if !recentHistory.isEmpty {
                     VStack(alignment: .leading, spacing: 12) {
-                        Text(L10n.Home.recentActivity)
-                            .font(.headline)
+                        HStack {
+                            Text(L10n.Home.recentActivity)
+                                .font(.headline)
+
+                            Spacer()
+
+                            Button(action: onShowAllLogs) {
+                                Text(L10n.Home.recentActivityShowAll)
+                                    .font(.subheadline)
+                                    .fontWeight(.semibold)
+                            }
+                            .buttonStyle(.plain)
+                            .tint(.accentColor)
+                        }
 
                         VStack(spacing: 12) {
-                            ForEach(state.history) { action in
+                            ForEach(recentHistory) { action in
                                 HistoryRow(action: action)
                             }
                         }

--- a/babynanny/Localization.swift
+++ b/babynanny/Localization.swift
@@ -16,6 +16,7 @@ enum L10n {
 
     enum Home {
         static let recentActivity = String(localized: "home.recentActivity", defaultValue: "Recent Activity")
+        static let recentActivityShowAll = String(localized: "home.recentActivity.showAll", defaultValue: "Show All")
         static let headerTitle = String(localized: "home.header.title", defaultValue: "Log today's care actions")
         static let placeholder = String(localized: "home.header.placeholder", defaultValue: "Start an action below to begin tracking your baby's day.")
         static let noEntries = String(localized: "home.noEntries", defaultValue: "No entries yet")

--- a/babynanny/de.lproj/Localizable.strings
+++ b/babynanny/de.lproj/Localizable.strings
@@ -6,6 +6,7 @@
 "common.cancel" = "Abbrechen";
 "common.done" = "Fertig";
 "home.recentActivity" = "Letzte Aktivitäten";
+"home.recentActivity.showAll" = "Alle anzeigen";
 "home.header.title" = "Erfasse die heutigen Pflegeaktivitäten";
 "home.header.placeholder" = "Starte unten eine Aktion, um den Tag deines Babys zu verfolgen.";
 "home.noEntries" = "Noch keine Einträge";

--- a/babynanny/en.lproj/Localizable.strings
+++ b/babynanny/en.lproj/Localizable.strings
@@ -6,6 +6,7 @@
 "common.cancel" = "Cancel";
 "common.done" = "Done";
 "home.recentActivity" = "Recent Activity";
+"home.recentActivity.showAll" = "Show All";
 "home.header.title" = "Log today's care actions";
 "home.header.placeholder" = "Start an action below to begin tracking your baby's day.";
 "home.noEntries" = "No entries yet";

--- a/babynanny/es.lproj/Localizable.strings
+++ b/babynanny/es.lproj/Localizable.strings
@@ -6,6 +6,7 @@
 "common.cancel" = "Cancelar";
 "common.done" = "Listo";
 "home.recentActivity" = "Actividad reciente";
+"home.recentActivity.showAll" = "Ver todo";
 "home.header.title" = "Registra las actividades de cuidado de hoy";
 "home.header.placeholder" = "Inicia una acción abajo para comenzar a registrar el día de tu bebé.";
 "home.noEntries" = "Aún no hay registros";


### PR DESCRIPTION
## Summary
- show only the most recent completed entry for each action category in the Home Recent Activity list
- add a Show All button that opens the All Logs screen from Home
- expose a helper on the action state and localize the new label across supported languages

## Testing
- not run (iOS simulator unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e434c35d988320966db017da72203a