### PR TITLE
Fix StatsView category picker binding handling

### DIFF
--- a/babynanny/StatsView.swift
+++ b/babynanny/StatsView.swift
@@ -96,7 +96,7 @@ struct StatsView: View {
 
                     Spacer()
 
-                    categoryPicker(for: state, selection: focusCategory)
+                    categoryPicker(for: state)
                 }
 
                 if hasData {
@@ -166,9 +166,10 @@ struct StatsView: View {
         selectedCategory ?? state.mostRecentAction?.category ?? .sleep
     }
 
-    private func categoryPicker(for state: ProfileActionState,
-                                selection: BabyActionCategory) -> some View {
-        Picker(
+    private func categoryPicker(for state: ProfileActionState) -> some View {
+        let selection = resolvedCategory(for: state)
+
+        return Picker(
             selection: Binding(
                 get: { resolvedCategory(for: state) },
                 set: { newValue in


### PR DESCRIPTION
## Summary
- resolve the StatsView category picker binding by deriving the binding internally
- update the daily trend header to use the revised picker helper signature

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e437e200fc83208b594763b13b7505