### PR TITLE
Fix category picker binding type

### DIFF
--- a/babynanny/StatsView.swift
+++ b/babynanny/StatsView.swift
@@ -168,14 +168,15 @@ struct StatsView: View {
 
     private func categoryPicker(for state: ProfileActionState) -> some View {
         let selection = resolvedCategory(for: state)
+        let binding = Binding<BabyActionCategory>(
+            get: { resolvedCategory(for: state) },
+            set: { newValue in
+                selectedCategory = newValue
+            }
+        )
 
         return Picker(
-            selection: Binding(
-                get: { resolvedCategory(for: state) },
-                set: { newValue in
-                    selectedCategory = newValue
-                }
-            ),
+            selection: binding,
             label: {
                 HStack(spacing: 6) {
                     Image(systemName: selection.icon)


### PR DESCRIPTION
## Summary
- fix the StatsView category picker binding by introducing an explicit `Binding<BabyActionCategory>`
- ensure the menu label continues to reflect the currently resolved action category

## Testing
- Not run (xcodebuild unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e49f31c72c8320832a86f574a182f7