### PR TITLE
Fix empty axis label rendering

### DIFF
--- a/babynanny/StatsView.swift
+++ b/babynanny/StatsView.swift
@@ -118,6 +118,8 @@ struct StatsView: View {
                             AxisValueLabel {
                                 if let dateValue = value.as(Date.self) {
                                     Text(dateValue, format: .dateTime.weekday(.abbreviated))
+                                } else {
+                                    EmptyView()
                                 }
                             }
                         }


### PR DESCRIPTION
## Summary
- ensure the chart axis label builder always returns a view

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4a24544b083209fe238be4535fdac