### PR TITLE
Add swipe-to-delete profiles in settings

### DIFF
--- a/babynanny/ActionLogViewModel.swift
+++ b/babynanny/ActionLogViewModel.swift
@@ -357,6 +357,12 @@ final class ActionLogStore: ObservableObject {
         }
     }
 
+    func removeProfileData(for profileID: UUID) {
+        var profiles = storage.profiles
+        guard profiles.removeValue(forKey: profileID) != nil else { return }
+        storage = Self.sanitized(state: ActionStoreState(profiles: profiles))
+    }
+
     private func updateState(for profileID: UUID, _ updates: (inout ProfileActionState) -> Void) {
         var profiles = storage.profiles
         var profileState = profiles[profileID] ?? ProfileActionState()

--- a/babynanny/Localization.swift
+++ b/babynanny/Localization.swift
@@ -85,6 +85,21 @@ enum L10n {
         static let birthDate = String(localized: "profiles.birthDate", defaultValue: "Birth date")
         static let choosePhoto = String(localized: "profiles.choosePhoto", defaultValue: "Choose profile photo")
         static let removePhoto = String(localized: "profiles.removePhoto", defaultValue: "Remove profile photo")
+
+        static func deleteConfirmationTitle(_ name: String) -> String {
+            let format = String(localized: "profiles.delete.confirmationTitle", defaultValue: "Delete %@?")
+            return String(format: format, locale: Locale.current, name)
+        }
+
+        static func deleteConfirmationMessage(_ name: String) -> String {
+            let format = String(
+                localized: "profiles.delete.confirmationMessage",
+                defaultValue: "This will remove %@ and all associated activity logs."
+            )
+            return String(format: format, locale: Locale.current, name)
+        }
+
+        static let deleteAction = String(localized: "profiles.delete.action", defaultValue: "Delete Profile")
     }
 
     enum Settings {

--- a/babynanny/ProfileStore.swift
+++ b/babynanny/ProfileStore.swift
@@ -138,6 +138,19 @@ final class ProfileStore: ObservableObject {
         state = Self.sanitized(state: newState)
     }
 
+    func deleteProfile(_ profile: ChildProfile) {
+        guard let index = state.profiles.firstIndex(where: { $0.id == profile.id }) else { return }
+
+        var newState = state
+        newState.profiles.remove(at: index)
+
+        if newState.activeProfileID == profile.id {
+            newState.activeProfileID = newState.profiles.first?.id
+        }
+
+        state = Self.sanitized(state: newState)
+    }
+
     func updateActiveProfile(_ updates: (inout ChildProfile) -> Void) {
         guard let activeID = state.activeProfileID,
               let index = state.profiles.firstIndex(where: { $0.id == activeID }) else { return }

--- a/babynanny/de.lproj/Localizable.strings
+++ b/babynanny/de.lproj/Localizable.strings
@@ -36,6 +36,9 @@
 "profiles.birthDate" = "Geburtsdatum";
 "profiles.choosePhoto" = "Profilfoto auswählen";
 "profiles.removePhoto" = "Profilfoto entfernen";
+"profiles.delete.confirmationTitle" = "Profil %@ löschen?";
+"profiles.delete.confirmationMessage" = "Dadurch werden %@ und alle zugehörigen Aktivitätsprotokolle entfernt.";
+"profiles.delete.action" = "Profil löschen";
 "settings.notifications.section" = "Benachrichtigungen";
 "settings.notifications.enable" = "Erinnerungen aktivieren";
 "settings.about.section" = "Info";

--- a/babynanny/en.lproj/Localizable.strings
+++ b/babynanny/en.lproj/Localizable.strings
@@ -36,6 +36,9 @@
 "profiles.birthDate" = "Birth date";
 "profiles.choosePhoto" = "Choose profile photo";
 "profiles.removePhoto" = "Remove profile photo";
+"profiles.delete.confirmationTitle" = "Delete %@?";
+"profiles.delete.confirmationMessage" = "This will remove %@ and all associated activity logs.";
+"profiles.delete.action" = "Delete Profile";
 "settings.notifications.section" = "Notifications";
 "settings.notifications.enable" = "Enable reminders";
 "settings.about.section" = "About";

--- a/babynanny/es.lproj/Localizable.strings
+++ b/babynanny/es.lproj/Localizable.strings
@@ -36,6 +36,9 @@
 "profiles.birthDate" = "Fecha de nacimiento";
 "profiles.choosePhoto" = "Elegir foto de perfil";
 "profiles.removePhoto" = "Quitar foto de perfil";
+"profiles.delete.confirmationTitle" = "¿Eliminar el perfil de %@?";
+"profiles.delete.confirmationMessage" = "Esto eliminará el perfil de %@ y todos los registros de actividad asociados.";
+"profiles.delete.action" = "Eliminar perfil";
 "settings.notifications.section" = "Notificaciones";
 "settings.notifications.enable" = "Activar recordatorios";
 "settings.about.section" = "Acerca de";


### PR DESCRIPTION
## Summary
- add a trailing swipe action on Settings profiles that asks for confirmation before deleting
- remove the selected profile and its saved action logs when a deletion is confirmed
- localize the new deletion strings for English, German, and Spanish

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e4b7f4c83c8320b382c689965850fe