### PR TITLE
Show next reminder details in settings

### DIFF
--- a/babynanny/Localization.swift
+++ b/babynanny/Localization.swift
@@ -108,6 +108,30 @@ enum L10n {
         static let aboutSection = String(localized: "settings.about.section", defaultValue: "About")
         static let appVersion = String(localized: "settings.about.appVersion", defaultValue: "App Version")
         static let title = String(localized: "settings.title", defaultValue: "Settings")
+        static let nextReminderLabel = String(
+            localized: "settings.notifications.nextReminder.label",
+            defaultValue: "Next reminder"
+        )
+        static let nextReminderDisabled = String(
+            localized: "settings.notifications.nextReminder.disabled",
+            defaultValue: "Reminders are turned off."
+        )
+        static let nextReminderUnavailable = String(
+            localized: "settings.notifications.nextReminder.unavailable",
+            defaultValue: "No reminders scheduled yet."
+        )
+        static let nextReminderLoading = String(
+            localized: "settings.notifications.nextReminder.loading",
+            defaultValue: "Loading…"
+        )
+
+        static func nextReminderScheduled(_ date: String, _ detail: String) -> String {
+            let format = String(
+                localized: "settings.notifications.nextReminder.scheduled",
+                defaultValue: "%@ — %@"
+            )
+            return String(format: format, locale: Locale.current, date, detail)
+        }
     }
 
     enum Notifications {

--- a/babynanny/de.lproj/Localizable.strings
+++ b/babynanny/de.lproj/Localizable.strings
@@ -41,6 +41,11 @@
 "profiles.delete.action" = "Profil löschen";
 "settings.notifications.section" = "Benachrichtigungen";
 "settings.notifications.enable" = "Erinnerungen aktivieren";
+"settings.notifications.nextReminder.label" = "Nächste Erinnerung";
+"settings.notifications.nextReminder.disabled" = "Erinnerungen sind deaktiviert.";
+"settings.notifications.nextReminder.unavailable" = "Noch keine Erinnerungen geplant.";
+"settings.notifications.nextReminder.loading" = "Wird geladen …";
+"settings.notifications.nextReminder.scheduled" = "%@ – %@";
 "settings.about.section" = "Info";
 "settings.about.appVersion" = "App-Version";
 "settings.title" = "Einstellungen";

--- a/babynanny/en.lproj/Localizable.strings
+++ b/babynanny/en.lproj/Localizable.strings
@@ -41,6 +41,11 @@
 "profiles.delete.action" = "Delete Profile";
 "settings.notifications.section" = "Notifications";
 "settings.notifications.enable" = "Enable reminders";
+"settings.notifications.nextReminder.label" = "Next reminder";
+"settings.notifications.nextReminder.disabled" = "Reminders are turned off.";
+"settings.notifications.nextReminder.unavailable" = "No reminders scheduled yet.";
+"settings.notifications.nextReminder.loading" = "Loading…";
+"settings.notifications.nextReminder.scheduled" = "%@ — %@";
 "settings.about.section" = "About";
 "settings.about.appVersion" = "App Version";
 "settings.title" = "Settings";

--- a/babynanny/es.lproj/Localizable.strings
+++ b/babynanny/es.lproj/Localizable.strings
@@ -41,6 +41,11 @@
 "profiles.delete.action" = "Eliminar perfil";
 "settings.notifications.section" = "Notificaciones";
 "settings.notifications.enable" = "Activar recordatorios";
+"settings.notifications.nextReminder.label" = "Próximo recordatorio";
+"settings.notifications.nextReminder.disabled" = "Los recordatorios están desactivados.";
+"settings.notifications.nextReminder.unavailable" = "Todavía no hay recordatorios programados.";
+"settings.notifications.nextReminder.loading" = "Cargando…";
+"settings.notifications.nextReminder.scheduled" = "%@ — %@";
 "settings.about.section" = "Acerca de";
 "settings.about.appVersion" = "Versión de la app";
 "settings.title" = "Configuración";


### PR DESCRIPTION
## Summary
- expose reminder overview data from the scheduler so additional notification types can be supported later
- surface the next scheduled reminder beneath the notifications toggle in settings
- update localized strings for the new reminder status copy in English, German, and Spanish

## Testing
- Not run (requires Xcode/iOS simulator environment)


------
https://chatgpt.com/codex/tasks/task_e_68e4c608ab4483208ceceacfd2e469fb