### PR TITLE
Ensure reminder notifications follow birth date updates

### DIFF
--- a/babynannyTests/ReminderSchedulerTests.swift
+++ b/babynannyTests/ReminderSchedulerTests.swift
@@ -1,0 +1,117 @@
+import Foundation
+import Testing
+import UserNotifications
+@testable import babynanny
+
+@Suite("Reminder Scheduler")
+struct ReminderSchedulerTests {
+    @Test
+    func reschedulesAfterBirthDateChange() async throws {
+        let center = MockUserNotificationCenter()
+        let scheduler = UserNotificationReminderScheduler(center: center, calendar: .gregorianCurrent)
+
+        var profile = ChildProfile(
+            name: "Alex",
+            birthDate: Calendar.current.date(byAdding: .year, value: -1, to: Date()) ?? Date(),
+            remindersEnabled: true
+        )
+
+        await scheduler.refreshReminders(for: [profile])
+        #expect(center.pendingRequests.isEmpty == false)
+
+        let previousIdentifiers = Set(center.pendingRequests.map(\.identifier))
+
+        profile.birthDate = Calendar.current.date(byAdding: .month, value: -6, to: profile.birthDate) ?? profile.birthDate
+        await scheduler.refreshReminders(for: [profile])
+
+        let updatedIdentifiers = Set(center.pendingRequests.map(\.identifier))
+        let removedIdentifiers = previousIdentifiers.subtracting(updatedIdentifiers)
+
+        #expect(removedIdentifiers.isEmpty == false)
+        #expect(center.removedIdentifiersHistory.flatMap { $0 }.contains(where: removedIdentifiers.contains))
+    }
+
+    @Test
+    func removesAndReschedulesWhenUpdateFails() async throws {
+        let center = MockUserNotificationCenter()
+        let scheduler = UserNotificationReminderScheduler(center: center, calendar: .gregorianCurrent)
+
+        var profile = ChildProfile(
+            name: "Maya",
+            birthDate: Calendar.current.date(byAdding: .month, value: -3, to: Date()) ?? Date(),
+            remindersEnabled: true
+        )
+
+        await scheduler.refreshReminders(for: [profile])
+        guard let targetIdentifier = center.pendingRequests.first?.identifier else {
+            Issue.record("No reminder scheduled for profile")
+            return
+        }
+
+        center.addFailures[targetIdentifier] = 1
+
+        profile.name = "Amelia"
+        await scheduler.refreshReminders(for: [profile])
+
+        #expect(center.addCallCounts[targetIdentifier] == 2)
+        #expect(center.removedIdentifiersHistory.flatMap { $0 }.contains(targetIdentifier))
+        let updatedRequest = center.pendingRequests.first { $0.identifier == targetIdentifier }
+        #expect(updatedRequest?.content.body.contains("Amelia") == true)
+    }
+}
+
+// MARK: - Helpers
+
+private final class MockUserNotificationCenter: UserNotificationCenterType {
+    var authorizationStatusValue: UNAuthorizationStatus = .authorized
+    var requestAuthorizationOptions: UNAuthorizationOptions?
+    var requestAuthorizationResult: Bool = true
+    private(set) var pendingRequests: [UNNotificationRequest] = []
+    private(set) var removedIdentifiersHistory: [[String]] = []
+    var addCallCounts: [String: Int] = [:]
+    var addFailures: [String: Int] = [:]
+
+    func authorizationStatus() async -> UNAuthorizationStatus {
+        authorizationStatusValue
+    }
+
+    func requestAuthorization(options: UNAuthorizationOptions) async throws -> Bool {
+        requestAuthorizationOptions = options
+        return requestAuthorizationResult
+    }
+
+    func pendingNotificationRequests() async -> [UNNotificationRequest] {
+        pendingRequests
+    }
+
+    func add(_ request: UNNotificationRequest, withCompletionHandler completionHandler: ((Error?) -> Void)?) {
+        addCallCounts[request.identifier, default: 0] += 1
+
+        if let remainingFailures = addFailures[request.identifier], remainingFailures > 0 {
+            addFailures[request.identifier] = remainingFailures - 1
+            completionHandler?(TestError.addFailed)
+            return
+        }
+
+        pendingRequests.removeAll { $0.identifier == request.identifier }
+        pendingRequests.append(request)
+        completionHandler?(nil)
+    }
+
+    func removePendingNotificationRequests(withIdentifiers identifiers: [String]) {
+        removedIdentifiersHistory.append(identifiers)
+        pendingRequests.removeAll { identifiers.contains($0.identifier) }
+    }
+}
+
+private enum TestError: Error {
+    case addFailed
+}
+
+private extension Calendar {
+    static var gregorianCurrent: Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone.current
+        return calendar
+    }
+}


### PR DESCRIPTION
## Summary
- Introduce a notification center abstraction and smarter reminder refresh so birth date changes update existing scheduled notifications.
- Add retry handling that removes and recreates pending notifications if an update attempt fails.
- Cover the new scheduling behavior with tests backed by a mock notification center.

## Testing
- `xcodebuild test -project babynanny.xcodeproj -scheme babynanny -destination 'platform=iOS Simulator,name=iPhone 15 Pro'` *(fails: `xcodebuild` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e4c91b52888320b5622539e42a2df5