### PR TITLE
Allow editing the latest action from Home

### DIFF
--- a/babynanny/ActionLogViewModel.swift
+++ b/babynanny/ActionLogViewModel.swift
@@ -72,11 +72,11 @@ struct BabyAction: Identifiable, Codable {
 
     var id: UUID
     let category: BabyActionCategory
-    let startDate: Date
+    var startDate: Date
     var endDate: Date?
-    let diaperType: DiaperType?
-    let feedingType: FeedingType?
-    let bottleVolume: Int?
+    var diaperType: DiaperType?
+    var feedingType: FeedingType?
+    var bottleVolume: Int?
 
     init(id: UUID = UUID(),
          category: BabyActionCategory,
@@ -365,6 +365,20 @@ final class ActionLogStore: ObservableObject {
             guard var action = profileState.activeActions.removeValue(forKey: category) else { return }
             action.endDate = Date()
             profileState.history.insert(action, at: 0)
+        }
+    }
+
+    func updateAction(for profileID: UUID, action updatedAction: BabyAction) {
+        updateState(for: profileID) { profileState in
+            if let index = profileState.history.firstIndex(where: { $0.id == updatedAction.id }) {
+                profileState.history[index] = updatedAction
+            }
+
+            for (category, action) in profileState.activeActions {
+                guard action.id == updatedAction.id else { continue }
+                profileState.activeActions[category] = updatedAction
+                break
+            }
         }
     }
 

--- a/babynanny/Localization.swift
+++ b/babynanny/Localization.swift
@@ -20,6 +20,7 @@ enum L10n {
         static let headerTitle = String(localized: "home.header.title", defaultValue: "Last Action")
         static let placeholder = String(localized: "home.header.placeholder", defaultValue: "Start an action below to begin tracking your baby's day.")
         static let noEntries = String(localized: "home.noEntries", defaultValue: "No entries yet")
+        static let editActionButton = String(localized: "home.header.edit", defaultValue: "Edit")
         static let sleepInfo = String(localized: "home.sleep.info", defaultValue: "Start tracking a sleep session. Stop it when your little one wakes up to capture the total rest time.")
         static let diaperTypeSectionTitle = String(localized: "home.diaper.sectionTitle", defaultValue: "Diaper type")
         static let diaperTypePickerLabel = String(localized: "home.diaper.pickerLabel", defaultValue: "Diaper type")
@@ -29,6 +30,12 @@ enum L10n {
         static let bottleVolumePickerLabel = String(localized: "home.bottle.pickerLabel", defaultValue: "Bottle volume")
         static let customVolumeFieldPlaceholder = String(localized: "home.bottle.customFieldPlaceholder", defaultValue: "Custom volume (ml)")
         static let customBottleOption = String(localized: "home.bottle.customOption", defaultValue: "Custom")
+        static let editActionTitle = String(localized: "home.sheet.editActionTitle", defaultValue: "Edit Action")
+        static let editStartSectionTitle = String(localized: "home.edit.startSectionTitle", defaultValue: "Start time")
+        static let editStartPickerLabel = String(localized: "home.edit.startPickerLabel", defaultValue: "Start")
+        static let editCategoryLabel = String(localized: "home.edit.categoryLabel", defaultValue: "Category")
+        static let editEndSectionTitle = String(localized: "home.edit.endSectionTitle", defaultValue: "End time")
+        static let editEndNote = String(localized: "home.edit.endNote", defaultValue: "End time can't be changed from here.")
 
         static func activeFor(_ duration: String) -> String {
             let format = String(localized: "home.header.activeFor", defaultValue: "Active for %@")

--- a/babynanny/de.lproj/Localizable.strings
+++ b/babynanny/de.lproj/Localizable.strings
@@ -8,6 +8,7 @@
 "home.recentActivity" = "Letzte Aktivitäten";
 "home.recentActivity.showAll" = "Alle anzeigen";
 "home.header.title" = "Letzte Aktion";
+"home.header.edit" = "Bearbeiten";
 "home.header.placeholder" = "Starte unten eine Aktion, um den Tag deines Babys zu verfolgen.";
 "home.noEntries" = "Noch keine Einträge";
 "home.sleep.info" = "Starte eine Schlafsitzung. Beende sie, wenn dein Kind aufwacht, um die gesamte Ruhezeit zu erfassen.";
@@ -19,6 +20,12 @@
 "home.bottle.pickerLabel" = "Flaschenmenge";
 "home.bottle.customFieldPlaceholder" = "Individuelles Volumen (ml)";
 "home.bottle.customOption" = "Individuell";
+"home.sheet.editActionTitle" = "Aktion bearbeiten";
+"home.edit.startSectionTitle" = "Startzeit";
+"home.edit.startPickerLabel" = "Start";
+"home.edit.categoryLabel" = "Kategorie";
+"home.edit.endSectionTitle" = "Endzeit";
+"home.edit.endNote" = "Die Endzeit kann hier nicht geändert werden.";
 "home.header.activeFor" = "Aktiv seit %@";
 "home.header.lastFinished" = "Zuletzt beendet %@";
 "home.card.startedAt" = "Gestartet um %@";

--- a/babynanny/en.lproj/Localizable.strings
+++ b/babynanny/en.lproj/Localizable.strings
@@ -8,6 +8,7 @@
 "home.recentActivity" = "Recent Activity";
 "home.recentActivity.showAll" = "Show All";
 "home.header.title" = "Last Action";
+"home.header.edit" = "Edit";
 "home.header.placeholder" = "Start an action below to begin tracking your baby's day.";
 "home.noEntries" = "No entries yet";
 "home.sleep.info" = "Start tracking a sleep session. Stop it when your little one wakes up to capture the total rest time.";
@@ -19,6 +20,12 @@
 "home.bottle.pickerLabel" = "Bottle volume";
 "home.bottle.customFieldPlaceholder" = "Custom volume (ml)";
 "home.bottle.customOption" = "Custom";
+"home.sheet.editActionTitle" = "Edit Action";
+"home.edit.startSectionTitle" = "Start time";
+"home.edit.startPickerLabel" = "Start";
+"home.edit.categoryLabel" = "Category";
+"home.edit.endSectionTitle" = "End time";
+"home.edit.endNote" = "End time can't be changed from here.";
 "home.header.activeFor" = "Active for %@";
 "home.header.lastFinished" = "Last finished %@";
 "home.card.startedAt" = "Started at %@";

--- a/babynanny/es.lproj/Localizable.strings
+++ b/babynanny/es.lproj/Localizable.strings
@@ -8,6 +8,7 @@
 "home.recentActivity" = "Actividad reciente";
 "home.recentActivity.showAll" = "Ver todo";
 "home.header.title" = "Última acción";
+"home.header.edit" = "Editar";
 "home.header.placeholder" = "Inicia una acción abajo para comenzar a registrar el día de tu bebé.";
 "home.noEntries" = "Aún no hay registros";
 "home.sleep.info" = "Inicia una sesión de sueño. Detenla cuando tu pequeño despierte para capturar el tiempo total de descanso.";
@@ -19,6 +20,12 @@
 "home.bottle.pickerLabel" = "Volumen del biberón";
 "home.bottle.customFieldPlaceholder" = "Volumen personalizado (ml)";
 "home.bottle.customOption" = "Personalizado";
+"home.sheet.editActionTitle" = "Editar acción";
+"home.edit.startSectionTitle" = "Hora de inicio";
+"home.edit.startPickerLabel" = "Inicio";
+"home.edit.categoryLabel" = "Categoría";
+"home.edit.endSectionTitle" = "Hora de finalización";
+"home.edit.endNote" = "La hora de finalización no se puede cambiar aquí.";
 "home.header.activeFor" = "Activo durante %@";
 "home.header.lastFinished" = "Última finalización %@";
 "home.card.startedAt" = "Iniciado a las %@";


### PR DESCRIPTION
## Summary
- add an edit control on the home screen header that opens an editor for the most recent action
- implement an ActionEditSheet and ActionLogStore.updateAction so start time and details can be changed while leaving the end time untouched
- localize the new editing strings in English, German, and Spanish

## Testing
- Not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e4ce631a44832090be8087e3125aea