### PR TITLE
Show duration in home action card last run text

### DIFF
--- a/babynanny/HomeView.swift
+++ b/babynanny/HomeView.swift
@@ -245,7 +245,11 @@ private struct ActionCard: View {
 
             } else {
                 if let lastCompleted {
-                    Text(L10n.Home.lastRun(lastCompleted.endDateTimeDescription() ?? lastCompleted.startDateTimeDescription()))
+                    let timestampDescription = lastCompleted.endDateTimeDescription()
+                        ?? lastCompleted.startDateTimeDescription()
+                    let durationDescription = lastCompleted.durationDescription()
+
+                    Text(L10n.Home.lastRunWithDuration(timestampDescription, durationDescription))
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }

--- a/babynanny/Localization.swift
+++ b/babynanny/Localization.swift
@@ -62,6 +62,14 @@ enum L10n {
             return String(format: format, locale: Locale.current, value)
         }
 
+        static func lastRunWithDuration(_ value: String, _ duration: String) -> String {
+            let format = String(
+                localized: "home.card.lastRunWithDuration",
+                defaultValue: "Last run %@ • Duration %@"
+            )
+            return String(format: format, locale: Locale.current, value, duration)
+        }
+
         static func newActionTitle(_ categoryTitle: String) -> String {
             let format = String(localized: "home.sheet.newActionTitle", defaultValue: "New %@ Action")
             return String(format: format, locale: Locale.current, categoryTitle)

--- a/babynanny/de.lproj/Localizable.strings
+++ b/babynanny/de.lproj/Localizable.strings
@@ -31,6 +31,7 @@
 "home.card.startedAt" = "Gestartet um %@";
 "home.card.elapsed" = "Verstrichen: %@";
 "home.card.lastRun" = "Zuletzt ausgeführt %@";
+"home.card.lastRunWithDuration" = "Zuletzt ausgeführt %@ • Dauer %@";
 "home.sheet.newActionTitle" = "Neue %@-Aktion";
 "home.bottle.presetLabel" = "%lld ml";
 "home.history.started" = "Gestartet %@";

--- a/babynanny/en.lproj/Localizable.strings
+++ b/babynanny/en.lproj/Localizable.strings
@@ -31,6 +31,7 @@
 "home.card.startedAt" = "Started at %@";
 "home.card.elapsed" = "Elapsed: %@";
 "home.card.lastRun" = "Last run %@";
+"home.card.lastRunWithDuration" = "Last run %@ • Duration %@";
 "home.sheet.newActionTitle" = "New %@ Action";
 "home.bottle.presetLabel" = "%lld ml";
 "home.history.started" = "Started %@";

--- a/babynanny/es.lproj/Localizable.strings
+++ b/babynanny/es.lproj/Localizable.strings
@@ -31,6 +31,7 @@
 "home.card.startedAt" = "Iniciado a las %@";
 "home.card.elapsed" = "Transcurrido: %@";
 "home.card.lastRun" = "Última ejecución %@";
+"home.card.lastRunWithDuration" = "Última ejecución %@ • Duración %@";
 "home.sheet.newActionTitle" = "Nueva acción de %@";
 "home.bottle.presetLabel" = "%lld ml";
 "home.history.started" = "Iniciado %@";


### PR DESCRIPTION
## Summary
- add a localized string for showing last run timestamps with their duration on home action cards
- update the action card view to include the duration alongside the last run timestamp
- provide translations for the new text in English, German, and Spanish

## Testing
- not run (Xcode build not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e4d8245f708320a73bd7875929ef29