### PR TITLE
Allow editing actions from All Logs and normalize action dates

### DIFF
--- a/babynanny/ActionLogViewModel.swift
+++ b/babynanny/ActionLogViewModel.swift
@@ -380,13 +380,14 @@ final class ActionLogStore: ObservableObject {
 
     func updateAction(for profileID: UUID, action updatedAction: BabyAction) {
         updateState(for: profileID) { profileState in
+            let normalizedAction = updatedAction.withValidatedDates()
             if let index = profileState.history.firstIndex(where: { $0.id == updatedAction.id }) {
-                profileState.history[index] = updatedAction
+                profileState.history[index] = normalizedAction
             }
 
             for (category, action) in profileState.activeActions {
                 guard action.id == updatedAction.id else { continue }
-                profileState.activeActions[category] = updatedAction
+                profileState.activeActions[category] = normalizedAction
                 break
             }
         }

--- a/babynanny/AllLogsView.swift
+++ b/babynanny/AllLogsView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct AllLogsView: View {
     @EnvironmentObject private var profileStore: ProfileStore
     @EnvironmentObject private var actionStore: ActionLogStore
+    @State private var editingAction: BabyAction?
 
     private let calendar = Calendar.current
     private let dateFormatter: DateFormatter = {
@@ -25,6 +26,12 @@ struct AllLogsView: View {
         .navigationTitle(L10n.Logs.title)
         .navigationBarTitleDisplayMode(.inline)
         .background(Color(.systemGroupedBackground).ignoresSafeArea())
+        .sheet(item: $editingAction) { action in
+            ActionEditSheet(action: action) { updatedAction in
+                actionStore.updateAction(for: profileStore.activeProfile.id, action: updatedAction)
+                editingAction = nil
+            }
+        }
     }
 
     @ViewBuilder
@@ -85,30 +92,35 @@ struct AllLogsView: View {
     }
 
     private func logRow(for action: BabyAction, asOf referenceDate: Date) -> some View {
-        HStack(alignment: .top, spacing: 16) {
-            ZStack {
-                Circle()
-                    .fill(action.category.accentColor.opacity(0.15))
-                    .frame(width: 36, height: 36)
+        Button {
+            editingAction = action
+        } label: {
+            HStack(alignment: .top, spacing: 16) {
+                ZStack {
+                    Circle()
+                        .fill(action.category.accentColor.opacity(0.15))
+                        .frame(width: 36, height: 36)
 
-                Image(systemName: action.icon)
-                    .font(.system(size: 18, weight: .semibold))
-                    .foregroundStyle(action.category.accentColor)
-            }
+                    Image(systemName: action.icon)
+                        .font(.system(size: 18, weight: .semibold))
+                        .foregroundStyle(action.category.accentColor)
+                }
 
-            VStack(alignment: .leading, spacing: 4) {
-                Text(L10n.Logs.entryTitle(timeFormatter.string(from: action.startDate),
-                                           durationDescription(for: action, asOf: referenceDate),
-                                           actionSummary(for: action)))
-                    .font(.headline)
-                    .foregroundStyle(.primary)
-                if let detail = detailedDescription(for: action) {
-                    Text(detail)
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(L10n.Logs.entryTitle(timeFormatter.string(from: action.startDate),
+                                               durationDescription(for: action, asOf: referenceDate),
+                                               actionSummary(for: action)))
+                        .font(.headline)
+                        .foregroundStyle(.primary)
+                    if let detail = detailedDescription(for: action) {
+                        Text(detail)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
                 }
             }
         }
+        .buttonStyle(.plain)
     }
 
     private func durationDescription(for action: BabyAction, asOf referenceDate: Date) -> String {

--- a/babynanny/HomeView.swift
+++ b/babynanny/HomeView.swift
@@ -356,7 +356,7 @@ private enum BottleVolumeOption: Hashable, Identifiable {
     }
 }
 
-private struct ActionEditSheet: View {
+struct ActionEditSheet: View {
     let action: BabyAction
     let onSave: (BabyAction) -> Void
 
@@ -518,7 +518,7 @@ private struct ActionEditSheet: View {
             updated.bottleVolume = feedingSelection.requiresVolume ? resolvedBottleVolume : nil
         }
 
-        onSave(updated)
+        onSave(updated.withValidatedDates())
         dismiss()
     }
 }


### PR DESCRIPTION
## Summary
- enable tapping All Logs entries to open the existing action edit sheet and persist changes
- reuse the edit sheet across views and normalize saved actions so instant entries keep matching start/end times and end dates never precede starts

## Testing
- Not run (xcodebuild unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e4d7fbb4a48320b9857fb3c8486680