### PR TITLE
Allow editing end times for completed actions

### DIFF
--- a/babynanny/Localization.swift
+++ b/babynanny/Localization.swift
@@ -35,7 +35,11 @@ enum L10n {
         static let editStartPickerLabel = String(localized: "home.edit.startPickerLabel", defaultValue: "Start")
         static let editCategoryLabel = String(localized: "home.edit.categoryLabel", defaultValue: "Category")
         static let editEndSectionTitle = String(localized: "home.edit.endSectionTitle", defaultValue: "End time")
-        static let editEndNote = String(localized: "home.edit.endNote", defaultValue: "End time can't be changed from here.")
+        static let editEndPickerLabel = String(localized: "home.edit.endPickerLabel", defaultValue: "End")
+        static let editEndNote = String(
+            localized: "home.edit.endNote",
+            defaultValue: "End time can be adjusted once the action has ended."
+        )
 
         static func activeFor(_ duration: String) -> String {
             let format = String(localized: "home.header.activeFor", defaultValue: "Active for %@")

--- a/babynanny/de.lproj/Localizable.strings
+++ b/babynanny/de.lproj/Localizable.strings
@@ -25,7 +25,8 @@
 "home.edit.startPickerLabel" = "Start";
 "home.edit.categoryLabel" = "Kategorie";
 "home.edit.endSectionTitle" = "Endzeit";
-"home.edit.endNote" = "Die Endzeit kann hier nicht geändert werden.";
+"home.edit.endPickerLabel" = "Ende";
+"home.edit.endNote" = "Die Endzeit kann angepasst werden, sobald die Aktion beendet wurde.";
 "home.header.activeFor" = "Aktiv seit %@";
 "home.header.lastFinished" = "Zuletzt beendet %@";
 "home.card.startedAt" = "Gestartet um %@";

--- a/babynanny/en.lproj/Localizable.strings
+++ b/babynanny/en.lproj/Localizable.strings
@@ -25,7 +25,8 @@
 "home.edit.startPickerLabel" = "Start";
 "home.edit.categoryLabel" = "Category";
 "home.edit.endSectionTitle" = "End time";
-"home.edit.endNote" = "End time can't be changed from here.";
+"home.edit.endPickerLabel" = "End";
+"home.edit.endNote" = "End time can be adjusted once the action has ended.";
 "home.header.activeFor" = "Active for %@";
 "home.header.lastFinished" = "Last finished %@";
 "home.card.startedAt" = "Started at %@";

--- a/babynanny/es.lproj/Localizable.strings
+++ b/babynanny/es.lproj/Localizable.strings
@@ -25,7 +25,8 @@
 "home.edit.startPickerLabel" = "Inicio";
 "home.edit.categoryLabel" = "Categoría";
 "home.edit.endSectionTitle" = "Hora de finalización";
-"home.edit.endNote" = "La hora de finalización no se puede cambiar aquí.";
+"home.edit.endPickerLabel" = "Fin";
+"home.edit.endNote" = "La hora de finalización se podrá ajustar cuando la acción haya terminado.";
 "home.header.activeFor" = "Activo durante %@";
 "home.header.lastFinished" = "Última finalización %@";
 "home.card.startedAt" = "Iniciado a las %@";


### PR DESCRIPTION
## Summary
- enable end-time editing in the action editor only for completed, non-instant actions
- refresh localization strings to support the new end-time picker label and guidance

## Testing
- not run (iOS simulator not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e4d9eff85c8320bcd3444e7aba7ca7