### PR TITLE
Increase spacing between log entries in AllLogsView

### DIFF
--- a/babynanny/AllLogsView.swift
+++ b/babynanny/AllLogsView.swift
@@ -63,6 +63,7 @@ struct AllLogsView: View {
                     }
                 }
             }
+            .listRowSpacing(12)
             .listStyle(.insetGrouped)
             .scrollContentBackground(.hidden)
             .background(Color(.systemGroupedBackground))


### PR DESCRIPTION
## Summary
- increase vertical spacing between log entries on the All Logs screen for improved readability

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e4dba609048320aaeb835575cbd09d