### PR TITLE
Allow editing end date beyond current time

### DIFF
--- a/babynanny/HomeView.swift
+++ b/babynanny/HomeView.swift
@@ -509,9 +509,7 @@ struct ActionEditSheet: View {
     }
 
     private var endDateRange: ClosedRange<Date> {
-        let potentialUpperBounds = [endDate ?? action.endDate, Date()].compactMap { $0 }
-        let resolvedUpperBound = potentialUpperBounds.max() ?? Date()
-        return startDate...max(startDate, resolvedUpperBound)
+        startDate...Date.distantFuture
     }
 
     private var endDateBinding: Binding<Date> {


### PR DESCRIPTION
## Summary
- allow selecting any end date after the start when editing an action

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4dc543b248320b7a17bae9679d9ea