### PR TITLE
Adjust spacing for All Logs list items

### DIFF
--- a/babynanny/AllLogsView.swift
+++ b/babynanny/AllLogsView.swift
@@ -58,12 +58,12 @@ struct AllLogsView: View {
                     Section(header: Text(dateFormatter.string(from: entry.date))) {
                         ForEach(entry.actions) { action in
                             logRow(for: action, asOf: referenceDate)
-                                .listRowInsets(EdgeInsets(top: 12, leading: 16, bottom: 12, trailing: 16))
+                                .listRowInsets(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
                         }
                     }
                 }
             }
-            .listRowSpacing(12)
+            .listRowSpacing(0)
             .listStyle(.insetGrouped)
             .scrollContentBackground(.hidden)
             .background(Color(.systemGroupedBackground))
@@ -120,6 +120,7 @@ struct AllLogsView: View {
                     }
                 }
             }
+            .padding(.vertical, 12)
         }
         .buttonStyle(.plain)
     }


### PR DESCRIPTION
## Summary
- remove the gap between entries on the All Logs screen to align the list items without extra spacing
- add additional vertical padding inside each log row to maintain a comfortable touch target

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e4dcc2a61c8320b912c2c447995dee