### PR TITLE
Add deletion controls to action logs

### DIFF
--- a/babynanny/ActionLogViewModel.swift
+++ b/babynanny/ActionLogViewModel.swift
@@ -393,6 +393,21 @@ final class ActionLogStore: ObservableObject {
         }
     }
 
+    func deleteAction(for profileID: UUID, actionID: UUID) {
+        updateState(for: profileID) { profileState in
+            profileState.history.removeAll { $0.id == actionID }
+
+            let categoriesToRemove = profileState.activeActions.compactMap { element -> BabyActionCategory? in
+                let (category, action) = element
+                return action.id == actionID ? category : nil
+            }
+
+            for category in categoriesToRemove {
+                profileState.activeActions.removeValue(forKey: category)
+            }
+        }
+    }
+
     func removeProfileData(for profileID: UUID) {
         var profiles = storage.profiles
         guard profiles.removeValue(forKey: profileID) != nil else { return }

--- a/babynanny/Localization.swift
+++ b/babynanny/Localization.swift
@@ -205,6 +205,12 @@ enum L10n {
         static let emptyTitle = String(localized: "logs.empty.title", defaultValue: "No logs yet")
         static let emptySubtitle = String(localized: "logs.empty.subtitle", defaultValue: "Actions you record will appear here, organized by day.")
         static let active = String(localized: "logs.active", defaultValue: "Active")
+        static let deleteConfirmationTitle = String(localized: "logs.delete.confirmationTitle", defaultValue: "Delete log?")
+        static let deleteConfirmationMessage = String(
+            localized: "logs.delete.confirmationMessage",
+            defaultValue: "Are you sure you want to delete this log? This action cannot be undone."
+        )
+        static let deleteAction = String(localized: "logs.delete.action", defaultValue: "Delete Log")
 
         static func entryTitle(_ startTime: String, _ duration: String, _ summary: String) -> String {
             let format = String(localized: "logs.entry.title", defaultValue: "%@, %@ %@")

--- a/babynanny/de.lproj/Localizable.strings
+++ b/babynanny/de.lproj/Localizable.strings
@@ -75,6 +75,9 @@
 "logs.empty.title" = "Noch keine Protokolle";
 "logs.empty.subtitle" = "Hier erscheinen deine aufgezeichneten Aktionen nach Tagen sortiert.";
 "logs.active" = "Aktiv";
+"logs.delete.confirmationTitle" = "Protokoll löschen?";
+"logs.delete.confirmationMessage" = "Möchtest du dieses Protokoll wirklich löschen? Dieser Vorgang kann nicht rückgängig gemacht werden.";
+"logs.delete.action" = "Protokoll löschen";
 "logs.entry.title" = "%@, %@ %@";
 "logs.summary.sleep" = "Schlaf";
 "logs.summary.diaperWithType" = "Windel – %@";

--- a/babynanny/en.lproj/Localizable.strings
+++ b/babynanny/en.lproj/Localizable.strings
@@ -75,6 +75,9 @@
 "logs.empty.title" = "No logs yet";
 "logs.empty.subtitle" = "Actions you record will appear here, organized by day.";
 "logs.active" = "Active";
+"logs.delete.confirmationTitle" = "Delete log?";
+"logs.delete.confirmationMessage" = "Are you sure you want to delete this log? This action cannot be undone.";
+"logs.delete.action" = "Delete Log";
 "logs.entry.title" = "%@, %@ %@";
 "logs.summary.sleep" = "sleep";
 "logs.summary.diaperWithType" = "diaper - %@";

--- a/babynanny/es.lproj/Localizable.strings
+++ b/babynanny/es.lproj/Localizable.strings
@@ -75,6 +75,9 @@
 "logs.empty.title" = "Todavía no hay registros";
 "logs.empty.subtitle" = "Las acciones que registres aparecerán aquí organizadas por día.";
 "logs.active" = "Activo";
+"logs.delete.confirmationTitle" = "¿Eliminar registro?";
+"logs.delete.confirmationMessage" = "¿Seguro que deseas eliminar este registro? Esta acción no se puede deshacer.";
+"logs.delete.action" = "Eliminar registro";
 "logs.entry.title" = "%@, %@ %@";
 "logs.summary.sleep" = "sueño";
 "logs.summary.diaperWithType" = "pañal – %@";


### PR DESCRIPTION
## Summary
- allow All Logs entries to be removed with a trailing swipe gesture and confirmation alert
- add a destructive delete action to the edit sheet that removes the selected log after confirmation
- update the action store and localizations to support deleting logs across supported languages

## Testing
- not run (iOS build tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e4ddde1758832084bd4489b499335b