### PR TITLE
Remove duplicated category labels from action card details

### DIFF
--- a/babynanny/Localization.swift
+++ b/babynanny/Localization.swift
@@ -288,17 +288,17 @@ enum L10n {
         static let diaperChange = String(localized: "actions.diaper.change", defaultValue: "Diaper change")
 
         static func diaperWithType(_ type: String) -> String {
-            let format = String(localized: "actions.diaper.withType", defaultValue: "Diaper: %@")
+            let format = String(localized: "actions.diaper.withType", defaultValue: "%@")
             return String(format: format, locale: Locale.current, type)
         }
 
         static func feedingBottle(_ volume: Int) -> String {
-            let format = String(localized: "actions.feeding.bottle", defaultValue: "Feeding: Bottle (%lld ml)")
+            let format = String(localized: "actions.feeding.bottle", defaultValue: "Bottle (%lld ml)")
             return String(format: format, locale: Locale.current, volume)
         }
 
         static func feedingWithType(_ type: String) -> String {
-            let format = String(localized: "actions.feeding.withType", defaultValue: "Feeding: %@")
+            let format = String(localized: "actions.feeding.withType", defaultValue: "%@")
             return String(format: format, locale: Locale.current, type)
         }
     }

--- a/babynanny/de.lproj/Localizable.strings
+++ b/babynanny/de.lproj/Localizable.strings
@@ -109,9 +109,9 @@
 "actions.diaper" = "Windel";
 "actions.feeding" = "Füttern";
 "actions.diaper.change" = "Windelwechsel";
-"actions.diaper.withType" = "Windel: %@";
-"actions.feeding.bottle" = "Füttern: Flasche (%lld ml)";
-"actions.feeding.withType" = "Füttern: %@";
+"actions.diaper.withType" = "%@";
+"actions.feeding.bottle" = "Flasche (%lld ml)";
+"actions.feeding.withType" = "%@";
 "diaper.pee" = "Nass";
 "diaper.poo" = "Stuhl";
 "diaper.both" = "Nass & Stuhl";

--- a/babynanny/en.lproj/Localizable.strings
+++ b/babynanny/en.lproj/Localizable.strings
@@ -109,9 +109,9 @@
 "actions.diaper" = "Diaper";
 "actions.feeding" = "Feeding";
 "actions.diaper.change" = "Diaper change";
-"actions.diaper.withType" = "Diaper: %@";
-"actions.feeding.bottle" = "Feeding: Bottle (%lld ml)";
-"actions.feeding.withType" = "Feeding: %@";
+"actions.diaper.withType" = "%@";
+"actions.feeding.bottle" = "Bottle (%lld ml)";
+"actions.feeding.withType" = "%@";
 "diaper.pee" = "Pee";
 "diaper.poo" = "Poo";
 "diaper.both" = "Pee & Poo";

--- a/babynanny/es.lproj/Localizable.strings
+++ b/babynanny/es.lproj/Localizable.strings
@@ -109,9 +109,9 @@
 "actions.diaper" = "Pañal";
 "actions.feeding" = "Alimentación";
 "actions.diaper.change" = "Cambio de pañal";
-"actions.diaper.withType" = "Pañal: %@";
-"actions.feeding.bottle" = "Alimentación: Biberón (%lld ml)";
-"actions.feeding.withType" = "Alimentación: %@";
+"actions.diaper.withType" = "%@";
+"actions.feeding.bottle" = "Biberón (%lld ml)";
+"actions.feeding.withType" = "%@";
 "diaper.pee" = "Mojado";
 "diaper.poo" = "Sólido";
 "diaper.both" = "Mojado y sólido";


### PR DESCRIPTION
## Summary
- update localization defaults so action card details omit redundant category prefixes
- adjust English, German, and Spanish strings to show only the selected diaper or feeding type text

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4e1aa49248320acb97ea510387eec