### PR TITLE
Add date range filtering to All Logs view

### DIFF
--- a/babynanny/AllLogsDateFilterSheet.swift
+++ b/babynanny/AllLogsDateFilterSheet.swift
@@ -1,0 +1,120 @@
+import SwiftUI
+
+struct AllLogsDateFilterSheet: View {
+    @Environment(\.dismiss) private var dismiss
+
+    private let calendar: Calendar
+    private let onApply: (Date?, Date?) -> Void
+    private let onClear: () -> Void
+
+    @State private var startDateSelection: Date
+    @State private var endDateSelection: Date
+    @State private var useStartDate: Bool
+    @State private var useEndDate: Bool
+
+    init(calendar: Calendar,
+         startDate: Date?,
+         endDate: Date?,
+         onApply: @escaping (Date?, Date?) -> Void,
+         onClear: @escaping () -> Void) {
+        self.calendar = calendar
+        self.onApply = onApply
+        self.onClear = onClear
+
+        let today = calendar.startOfDay(for: Date())
+        let normalizedStart = startDate.map { calendar.startOfDay(for: $0) }
+        let normalizedEnd = endDate.map { calendar.startOfDay(for: $0) }
+        let initialStart = normalizedStart ?? normalizedEnd ?? today
+        let initialEndCandidate = normalizedEnd ?? initialStart
+        let initialEnd = max(initialEndCandidate, initialStart)
+
+        _startDateSelection = State(initialValue: initialStart)
+        _endDateSelection = State(initialValue: initialEnd)
+        _useStartDate = State(initialValue: normalizedStart != nil)
+        _useEndDate = State(initialValue: normalizedEnd != nil)
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    Toggle(L10n.Logs.filterStartToggle, isOn: $useStartDate.animation())
+                    if useStartDate {
+                        DatePicker(
+                            L10n.Logs.filterStartLabel,
+                            selection: $startDateSelection,
+                            displayedComponents: .date
+                        )
+                    }
+                }
+
+                Section {
+                    Toggle(L10n.Logs.filterEndToggle, isOn: $useEndDate.animation())
+                    if useEndDate {
+                        DatePicker(
+                            L10n.Logs.filterEndLabel,
+                            selection: $endDateSelection,
+                            in: endDateRange,
+                            displayedComponents: .date
+                        )
+                    }
+                }
+
+                if useStartDate || useEndDate {
+                    Section {
+                        Button(L10n.Logs.filterClear) {
+                            clearSelection()
+                        }
+                    }
+                }
+            }
+            .navigationTitle(L10n.Logs.filterTitle)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(L10n.Common.cancel) {
+                        dismiss()
+                    }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(L10n.Common.done) {
+                        applySelection()
+                    }
+                }
+            }
+            .onChange(of: startDateSelection) { newValue in
+                if useEndDate, endDateSelection < newValue {
+                    endDateSelection = newValue
+                }
+            }
+            .onChange(of: useStartDate) { newValue in
+                if newValue, useEndDate, endDateSelection < startDateSelection {
+                    endDateSelection = startDateSelection
+                }
+            }
+            .onChange(of: useEndDate) { newValue in
+                if newValue, endDateSelection < startDateSelection {
+                    endDateSelection = startDateSelection
+                }
+            }
+        }
+    }
+
+    private var endDateRange: ClosedRange<Date> {
+        let lowerBound = useStartDate ? startDateSelection : Date.distantPast
+        return lowerBound...Date.distantFuture
+    }
+
+    private func applySelection() {
+        let start = useStartDate ? calendar.startOfDay(for: startDateSelection) : nil
+        let end = useEndDate ? calendar.startOfDay(for: endDateSelection) : nil
+        onApply(start, end)
+        dismiss()
+    }
+
+    private func clearSelection() {
+        useStartDate = false
+        useEndDate = false
+        onClear()
+        dismiss()
+    }
+}

--- a/babynanny/AllLogsRowView.swift
+++ b/babynanny/AllLogsRowView.swift
@@ -1,0 +1,80 @@
+import SwiftUI
+
+struct AllLogsRowView: View {
+    let action: BabyAction
+    let referenceDate: Date
+    let timeFormatter: DateFormatter
+    let onEdit: (BabyAction) -> Void
+    let onDelete: (BabyAction) -> Void
+
+    var body: some View {
+        Button {
+            onEdit(action)
+        } label: {
+            HStack(alignment: .top, spacing: 16) {
+                ZStack {
+                    Circle()
+                        .fill(action.category.accentColor.opacity(0.15))
+                        .frame(width: 36, height: 36)
+
+                    Image(systemName: action.icon)
+                        .font(.system(size: 18, weight: .semibold))
+                        .foregroundStyle(action.category.accentColor)
+                }
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(L10n.Logs.entryTitle(timeFormatter.string(from: action.startDate),
+                                               durationDescription,
+                                               actionSummary))
+                        .font(.headline)
+                        .foregroundStyle(.primary)
+                    if let detail = detailDescription {
+                        Text(detail)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            .padding(.vertical, 12)
+        }
+        .buttonStyle(.plain)
+        .swipeActions(edge: .trailing) {
+            Button(role: .destructive) {
+                onDelete(action)
+            } label: {
+                Label(L10n.Logs.deleteAction, systemImage: "trash")
+            }
+        }
+    }
+
+    private var durationDescription: String {
+        action.durationDescription(asOf: referenceDate)
+    }
+
+    private var actionSummary: String {
+        switch action.category {
+        case .sleep:
+            return L10n.Logs.summarySleep()
+        case .diaper:
+            if let type = action.diaperType {
+                return L10n.Logs.summaryDiaper(withType: type.title.localizedLowercase)
+            }
+            return L10n.Logs.summaryDiaper()
+        case .feeding:
+            if let type = action.feedingType {
+                if type == .bottle, let volume = action.bottleVolume {
+                    return L10n.Logs.summaryFeedingBottle(volume: volume)
+                }
+                return L10n.Logs.summaryFeeding(withType: type.title.localizedLowercase)
+            }
+            return L10n.Logs.summaryFeeding()
+        }
+    }
+
+    private var detailDescription: String? {
+        if action.endDate == nil {
+            return L10n.Logs.active
+        }
+        return nil
+    }
+}

--- a/babynanny/AllLogsView+Filtering.swift
+++ b/babynanny/AllLogsView+Filtering.swift
@@ -1,0 +1,102 @@
+import SwiftUI
+
+extension AllLogsView {
+    fileprivate func groupedActions() -> [(date: Date, actions: [BabyAction])] {
+        let actions = actionStore.state(for: profileStore.activeProfile.id).history
+        var grouped: [Date: [BabyAction]] = [:]
+        var orderedDates: [Date] = []
+
+        let filteredActions = actions.filter(isActionIncluded)
+
+        for action in filteredActions.sorted(by: { $0.startDate > $1.startDate }) {
+            let day = calendar.startOfDay(for: action.startDate)
+
+            if grouped[day] != nil {
+                grouped[day]?.append(action)
+            } else {
+                grouped[day] = [action]
+                orderedDates.append(day)
+            }
+        }
+
+        return orderedDates.map { date in
+            let actionsForDate = grouped[date] ?? []
+            return (date: date, actions: actionsForDate)
+        }
+    }
+
+    fileprivate func deleteAction(_ action: BabyAction) {
+        actionStore.deleteAction(for: profileStore.activeProfile.id, actionID: action.id)
+        if editingAction?.id == action.id {
+            editingAction = nil
+        }
+        if actionPendingDeletion?.id == action.id {
+            actionPendingDeletion = nil
+        }
+    }
+
+    fileprivate func applyFilter(startDate: Date?, endDate: Date?) {
+        var normalizedStart = startDate.map { calendar.startOfDay(for: $0) }
+        var normalizedEnd = endDate.map { calendar.startOfDay(for: $0) }
+
+        if let start = normalizedStart, let end = normalizedEnd, start > end {
+            normalizedEnd = start
+        }
+
+        filterStartDate = normalizedStart
+        filterEndDate = normalizedEnd
+    }
+
+    fileprivate func clearFilter() {
+        filterStartDate = nil
+        filterEndDate = nil
+    }
+
+    fileprivate func activeFilterDescription() -> String? {
+        switch (filterStartDate, filterEndDate) {
+        case let (start?, end?):
+            return L10n.Logs.filterSummaryRange(dateFormatter.string(from: start), dateFormatter.string(from: end))
+        case let (start?, nil):
+            return L10n.Logs.filterSummaryStart(dateFormatter.string(from: start))
+        case let (nil, end?):
+            return L10n.Logs.filterSummaryEnd(dateFormatter.string(from: end))
+        default:
+            return nil
+        }
+    }
+
+    fileprivate func filterSummaryView(_ description: String) -> some View {
+        HStack(spacing: 12) {
+            Label(description, systemImage: "line.3.horizontal.decrease.circle")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+
+            Spacer()
+
+            Button(action: clearFilter) {
+                Text(L10n.Logs.filterClear)
+                    .font(.subheadline.weight(.semibold))
+            }
+            .buttonStyle(.borderless)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(Color(.secondarySystemGroupedBackground))
+    }
+
+    fileprivate func isActionIncluded(_ action: BabyAction) -> Bool {
+        if let startBoundary = filterStartDate, action.startDate < startBoundary {
+            return false
+        }
+        if let endBoundary = filterEndDate {
+            if let nextDay = calendar.date(byAdding: .day, value: 1, to: endBoundary) {
+                if action.startDate >= nextDay {
+                    return false
+                }
+            } else if action.startDate > endBoundary {
+                return false
+            }
+        }
+        return true
+    }
+}

--- a/babynanny/AllLogsView+Preview.swift
+++ b/babynanny/AllLogsView+Preview.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+#Preview {
+    let profile = ChildProfile(name: "Aria", birthDate: Date())
+    var state = ProfileActionState()
+    state.history = [
+        BabyAction(
+            category: .sleep,
+            startDate: Date().addingTimeInterval(-3600),
+            endDate: Date().addingTimeInterval(-1800)
+        ),
+        BabyAction(
+            category: .feeding,
+            startDate: Date().addingTimeInterval(-7200),
+            endDate: Date().addingTimeInterval(-6600),
+            feedingType: .bottle,
+            bottleVolume: 120
+        ),
+        BabyAction(
+            category: .diaper,
+            startDate: Date().addingTimeInterval(-86000),
+            endDate: Date().addingTimeInterval(-85800),
+            diaperType: .pee
+        )
+    ]
+
+    let actionStore = ActionLogStore.previewStore(profiles: [profile.id: state])
+    let profileStore = ProfileStore(initialProfiles: [profile], activeProfileID: profile.id, directory: FileManager.default.temporaryDirectory, filename: "previewProfiles.json")
+
+    return NavigationStack {
+        AllLogsView()
+            .environmentObject(profileStore)
+            .environmentObject(actionStore)
+    }
+}

--- a/babynanny/Localization.swift
+++ b/babynanny/Localization.swift
@@ -211,10 +211,32 @@ enum L10n {
             defaultValue: "Are you sure you want to delete this log? This action cannot be undone."
         )
         static let deleteAction = String(localized: "logs.delete.action", defaultValue: "Delete Log")
+        static let filterButton = String(localized: "logs.filter.button", defaultValue: "Filter")
+        static let filterTitle = String(localized: "logs.filter.title", defaultValue: "Filter Logs")
+        static let filterStartToggle = String(localized: "logs.filter.startToggle", defaultValue: "Filter from date")
+        static let filterStartLabel = String(localized: "logs.filter.startLabel", defaultValue: "Start date")
+        static let filterEndToggle = String(localized: "logs.filter.endToggle", defaultValue: "Filter to date")
+        static let filterEndLabel = String(localized: "logs.filter.endLabel", defaultValue: "End date")
+        static let filterClear = String(localized: "logs.filter.clear", defaultValue: "Clear Filter")
 
         static func entryTitle(_ startTime: String, _ duration: String, _ summary: String) -> String {
             let format = String(localized: "logs.entry.title", defaultValue: "%@, %@ %@")
             return String(format: format, locale: Locale.current, startTime, duration, summary)
+        }
+
+        static func filterSummaryRange(_ start: String, _ end: String) -> String {
+            let format = String(localized: "logs.filter.summary.range", defaultValue: "Showing %@ – %@")
+            return String(format: format, locale: Locale.current, start, end)
+        }
+
+        static func filterSummaryStart(_ start: String) -> String {
+            let format = String(localized: "logs.filter.summary.start", defaultValue: "Showing from %@")
+            return String(format: format, locale: Locale.current, start)
+        }
+
+        static func filterSummaryEnd(_ end: String) -> String {
+            let format = String(localized: "logs.filter.summary.end", defaultValue: "Showing through %@")
+            return String(format: format, locale: Locale.current, end)
         }
 
         static func summarySleep() -> String {

--- a/babynanny/de.lproj/Localizable.strings
+++ b/babynanny/de.lproj/Localizable.strings
@@ -78,6 +78,16 @@
 "logs.delete.confirmationTitle" = "Protokoll löschen?";
 "logs.delete.confirmationMessage" = "Möchtest du dieses Protokoll wirklich löschen? Dieser Vorgang kann nicht rückgängig gemacht werden.";
 "logs.delete.action" = "Protokoll löschen";
+"logs.filter.button" = "Filter";
+"logs.filter.title" = "Protokolle filtern";
+"logs.filter.startToggle" = "Ab Datum filtern";
+"logs.filter.startLabel" = "Startdatum";
+"logs.filter.endToggle" = "Bis Datum filtern";
+"logs.filter.endLabel" = "Enddatum";
+"logs.filter.clear" = "Filter löschen";
+"logs.filter.summary.range" = "Angezeigt: %@ – %@";
+"logs.filter.summary.start" = "Angezeigt ab %@";
+"logs.filter.summary.end" = "Angezeigt bis %@";
 "logs.entry.title" = "%@, %@ %@";
 "logs.summary.sleep" = "Schlaf";
 "logs.summary.diaperWithType" = "Windel – %@";

--- a/babynanny/en.lproj/Localizable.strings
+++ b/babynanny/en.lproj/Localizable.strings
@@ -78,6 +78,16 @@
 "logs.delete.confirmationTitle" = "Delete log?";
 "logs.delete.confirmationMessage" = "Are you sure you want to delete this log? This action cannot be undone.";
 "logs.delete.action" = "Delete Log";
+"logs.filter.button" = "Filter";
+"logs.filter.title" = "Filter Logs";
+"logs.filter.startToggle" = "Filter from date";
+"logs.filter.startLabel" = "Start date";
+"logs.filter.endToggle" = "Filter to date";
+"logs.filter.endLabel" = "End date";
+"logs.filter.clear" = "Clear Filter";
+"logs.filter.summary.range" = "Showing %@ – %@";
+"logs.filter.summary.start" = "Showing from %@";
+"logs.filter.summary.end" = "Showing through %@";
 "logs.entry.title" = "%@, %@ %@";
 "logs.summary.sleep" = "sleep";
 "logs.summary.diaperWithType" = "diaper - %@";

--- a/babynanny/es.lproj/Localizable.strings
+++ b/babynanny/es.lproj/Localizable.strings
@@ -78,6 +78,16 @@
 "logs.delete.confirmationTitle" = "¿Eliminar registro?";
 "logs.delete.confirmationMessage" = "¿Seguro que deseas eliminar este registro? Esta acción no se puede deshacer.";
 "logs.delete.action" = "Eliminar registro";
+"logs.filter.button" = "Filtrar";
+"logs.filter.title" = "Filtrar registros";
+"logs.filter.startToggle" = "Filtrar desde fecha";
+"logs.filter.startLabel" = "Fecha de inicio";
+"logs.filter.endToggle" = "Filtrar hasta fecha";
+"logs.filter.endLabel" = "Fecha de fin";
+"logs.filter.clear" = "Borrar filtro";
+"logs.filter.summary.range" = "Mostrando %@ – %@";
+"logs.filter.summary.start" = "Mostrando desde %@";
+"logs.filter.summary.end" = "Mostrando hasta %@";
 "logs.entry.title" = "%@, %@ %@";
 "logs.summary.sleep" = "sueño";
 "logs.summary.diaperWithType" = "pañal – %@";


### PR DESCRIPTION
## Summary
- add date range controls and summary banner to the All Logs view
- filter the action history by the selected range and extract supporting SwiftUI components
- localize new filter strings for English, German, and Spanish

## Testing
- not run (simulator unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e4e08c986c8320b4455cad8ec9841c