### PR TITLE
Center last action timer and simplify duration label

### DIFF
--- a/babynanny/HomeView.swift
+++ b/babynanny/HomeView.swift
@@ -127,8 +127,11 @@ struct HomeView: View {
                     if recent.endDate == nil {
                         TimelineView(.periodic(from: .now, by: 1)) { context in
                             Text(L10n.Home.activeFor(recent.durationDescription(asOf: context.date)))
-                                .font(.caption)
+                                .font(.title3)
+                                .fontWeight(.semibold)
                                 .monospacedDigit()
+                                .frame(maxWidth: .infinity)
+                                .multilineTextAlignment(.center)
                                 .foregroundStyle(.secondary)
                         }
                     } else if let ended = recent.endDateTimeDescription() {

--- a/babynanny/Localization.swift
+++ b/babynanny/Localization.swift
@@ -69,7 +69,7 @@ enum L10n {
         static func lastRunWithDuration(_ value: String, _ duration: String) -> String {
             let format = String(
                 localized: "home.card.lastRunWithDuration",
-                defaultValue: "Last run %@ • Duration %@"
+                defaultValue: "Last run %@ • %@"
             )
             return String(format: format, locale: Locale.current, value, duration)
         }

--- a/babynanny/de.lproj/Localizable.strings
+++ b/babynanny/de.lproj/Localizable.strings
@@ -32,7 +32,7 @@
 "home.card.startedAt" = "Gestartet um %@";
 "home.card.elapsed" = "Verstrichen: %@";
 "home.card.lastRun" = "Zuletzt ausgeführt %@";
-"home.card.lastRunWithDuration" = "Zuletzt ausgeführt %@ • Dauer %@";
+"home.card.lastRunWithDuration" = "Zuletzt ausgeführt %@ • %@";
 "home.sheet.newActionTitle" = "Neue %@-Aktion";
 "home.bottle.presetLabel" = "%lld ml";
 "home.history.started" = "Gestartet %@";

--- a/babynanny/en.lproj/Localizable.strings
+++ b/babynanny/en.lproj/Localizable.strings
@@ -32,7 +32,7 @@
 "home.card.startedAt" = "Started at %@";
 "home.card.elapsed" = "Elapsed: %@";
 "home.card.lastRun" = "Last run %@";
-"home.card.lastRunWithDuration" = "Last run %@ • Duration %@";
+"home.card.lastRunWithDuration" = "Last run %@ • %@";
 "home.sheet.newActionTitle" = "New %@ Action";
 "home.bottle.presetLabel" = "%lld ml";
 "home.history.started" = "Started %@";

--- a/babynanny/es.lproj/Localizable.strings
+++ b/babynanny/es.lproj/Localizable.strings
@@ -32,7 +32,7 @@
 "home.card.startedAt" = "Iniciado a las %@";
 "home.card.elapsed" = "Transcurrido: %@";
 "home.card.lastRun" = "Última ejecución %@";
-"home.card.lastRunWithDuration" = "Última ejecución %@ • Duración %@";
+"home.card.lastRunWithDuration" = "Última ejecución %@ • %@";
 "home.sheet.newActionTitle" = "Nueva acción de %@";
 "home.bottle.presetLabel" = "%lld ml";
 "home.history.started" = "Iniciado %@";


### PR DESCRIPTION
## Summary
- center the active duration timer on the Home screen card and enlarge its typography for improved emphasis
- remove the "Duration" label from action card summaries so only the elapsed time is shown across all localizations

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4f52b15e8832087dafe38aadb2f26