### PR TITLE
Add swipe-to-edit action to all logs list

### DIFF
--- a/babynanny/AllLogsRowView.swift
+++ b/babynanny/AllLogsRowView.swift
@@ -38,6 +38,14 @@ struct AllLogsRowView: View {
             .padding(.vertical, 12)
         }
         .buttonStyle(.plain)
+        .swipeActions(edge: .leading, allowsFullSwipe: false) {
+            Button {
+                onEdit(action)
+            } label: {
+                Label(L10n.Logs.editAction, systemImage: "square.and.pencil")
+            }
+            .tint(.accentColor)
+        }
         .swipeActions(edge: .trailing) {
             Button(role: .destructive) {
                 onDelete(action)

--- a/babynanny/Localization.swift
+++ b/babynanny/Localization.swift
@@ -211,6 +211,7 @@ enum L10n {
             defaultValue: "Are you sure you want to delete this log? This action cannot be undone."
         )
         static let deleteAction = String(localized: "logs.delete.action", defaultValue: "Delete Log")
+        static let editAction = String(localized: "logs.edit.action", defaultValue: "Edit Log")
         static let filterButton = String(localized: "logs.filter.button", defaultValue: "Filter")
         static let filterTitle = String(localized: "logs.filter.title", defaultValue: "Filter Logs")
         static let filterStartToggle = String(localized: "logs.filter.startToggle", defaultValue: "Filter from date")

--- a/babynanny/de.lproj/Localizable.strings
+++ b/babynanny/de.lproj/Localizable.strings
@@ -78,6 +78,7 @@
 "logs.delete.confirmationTitle" = "Protokoll löschen?";
 "logs.delete.confirmationMessage" = "Möchtest du dieses Protokoll wirklich löschen? Dieser Vorgang kann nicht rückgängig gemacht werden.";
 "logs.delete.action" = "Protokoll löschen";
+"logs.edit.action" = "Protokoll bearbeiten";
 "logs.filter.button" = "Filter";
 "logs.filter.title" = "Protokolle filtern";
 "logs.filter.startToggle" = "Ab Datum filtern";

--- a/babynanny/en.lproj/Localizable.strings
+++ b/babynanny/en.lproj/Localizable.strings
@@ -78,6 +78,7 @@
 "logs.delete.confirmationTitle" = "Delete log?";
 "logs.delete.confirmationMessage" = "Are you sure you want to delete this log? This action cannot be undone.";
 "logs.delete.action" = "Delete Log";
+"logs.edit.action" = "Edit Log";
 "logs.filter.button" = "Filter";
 "logs.filter.title" = "Filter Logs";
 "logs.filter.startToggle" = "Filter from date";

--- a/babynanny/es.lproj/Localizable.strings
+++ b/babynanny/es.lproj/Localizable.strings
@@ -78,6 +78,7 @@
 "logs.delete.confirmationTitle" = "¿Eliminar registro?";
 "logs.delete.confirmationMessage" = "¿Seguro que deseas eliminar este registro? Esta acción no se puede deshacer.";
 "logs.delete.action" = "Eliminar registro";
+"logs.edit.action" = "Editar registro";
 "logs.filter.button" = "Filtrar";
 "logs.filter.title" = "Filtrar registros";
 "logs.filter.startToggle" = "Filtrar desde fecha";


### PR DESCRIPTION
## Summary
- add a leading swipe action in the all logs list so entries can be edited via swipe-right
- add localized strings for the new "Edit Log" action in English, German, and Spanish

## Testing
- Not run (iOS build tools unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e4f558c4b08320873d740f02251127