### PR TITLE
Adjust last action duration display

### DIFF
--- a/babynanny/HomeView.swift
+++ b/babynanny/HomeView.swift
@@ -126,7 +126,7 @@ struct HomeView: View {
 
                     if recent.endDate == nil {
                         TimelineView(.periodic(from: .now, by: 1)) { context in
-                            Text(L10n.Home.activeFor(recent.durationDescription(asOf: context.date)))
+                            Text(recent.durationDescription(asOf: context.date))
                                 .font(.title3)
                                 .fontWeight(.semibold)
                                 .monospacedDigit()
@@ -134,9 +134,12 @@ struct HomeView: View {
                                 .multilineTextAlignment(.center)
                                 .foregroundStyle(.secondary)
                         }
-                    } else if let ended = recent.endDateTimeDescription() {
-                        Text(L10n.Home.lastFinished(ended))
-                            .font(.caption)
+                    } else {
+                        Text(recent.durationDescription())
+                            .font(.title3)
+                            .fontWeight(.semibold)
+                            .monospacedDigit()
+                            .frame(maxWidth: .infinity, alignment: .leading)
                             .foregroundStyle(.secondary)
                     }
                 }


### PR DESCRIPTION
## Summary
- show the running action duration without the "Active for" prefix on the home header card
- display the completed action duration on the header card once the action stops instead of the "Last finished" label

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4ff2a7ce88320a5d14d931cd6fcab