### PR TITLE
Remove reminder preview button from settings

### DIFF
--- a/babynanny/Localization.swift
+++ b/babynanny/Localization.swift
@@ -203,15 +203,6 @@ enum L10n {
             defaultValue: "Reminders are turned off for this action."
         )
 
-        static let actionReminderPreview = String(
-            localized: "settings.notifications.actionReminder.preview",
-            defaultValue: "Preview"
-        )
-
-        static let actionReminderPreviewUnavailable = String(
-            localized: "settings.notifications.actionReminder.previewUnavailable",
-            defaultValue: "No reminder is scheduled yet. Try logging this action to schedule one."
-        )
     }
 
     enum Notifications {

--- a/babynanny/SettingsView.swift
+++ b/babynanny/SettingsView.swift
@@ -307,13 +307,6 @@ private extension SettingsView {
             .disabled(remindersEnabled == false || isCategoryEnabled == false)
 
             actionReminderStatus(for: category, isEnabled: remindersEnabled && isCategoryEnabled)
-
-            Button(L10n.Settings.actionReminderPreview) {
-                showReminderPreview(for: category)
-            }
-            .buttonStyle(.bordered)
-            .tint(category.accentColor)
-            .disabled(remindersEnabled == false || isCategoryEnabled == false)
         }
         .padding(.vertical, 4)
     }
@@ -355,14 +348,6 @@ private extension SettingsView {
         .padding(.vertical, 4)
     }
 
-    private func showReminderPreview(for category: BabyActionCategory) {
-        Task { @MainActor in
-            let result = await profileStore.scheduleActionReminderPreview(for: category)
-            if result == .authorizationDenied {
-                showNotificationsSettingsPrompt = true
-            }
-        }
-    }
 }
 
 #Preview {

--- a/babynanny/de.lproj/Localizable.strings
+++ b/babynanny/de.lproj/Localizable.strings
@@ -65,8 +65,6 @@
 "settings.notifications.actionReminder.frequency.one" = "Jede Stunde";
 "settings.notifications.actionReminder.frequency.other" = "Alle %lld Stunden";
 "settings.notifications.actionReminder.disabled" = "Erinnerungen für diese Aktion sind deaktiviert.";
-"settings.notifications.actionReminder.preview" = "Vorschau";
-"settings.notifications.actionReminder.previewUnavailable" = "Es ist noch keine Erinnerung geplant. Protokollieren Sie diese Aktion, um eine zu planen.";
 "settings.about.section" = "Info";
 "settings.about.appVersion" = "App-Version";
 "settings.title" = "Einstellungen";

--- a/babynanny/en.lproj/Localizable.strings
+++ b/babynanny/en.lproj/Localizable.strings
@@ -65,8 +65,6 @@
 "settings.notifications.actionReminder.frequency.one" = "Every hour";
 "settings.notifications.actionReminder.frequency.other" = "Every %lld hours";
 "settings.notifications.actionReminder.disabled" = "Reminders are turned off for this action.";
-"settings.notifications.actionReminder.preview" = "Preview";
-"settings.notifications.actionReminder.previewUnavailable" = "No reminder is scheduled yet. Try logging this action to schedule one.";
 "settings.about.section" = "About";
 "settings.about.appVersion" = "App Version";
 "settings.title" = "Settings";

--- a/babynanny/es.lproj/Localizable.strings
+++ b/babynanny/es.lproj/Localizable.strings
@@ -65,8 +65,6 @@
 "settings.notifications.actionReminder.frequency.one" = "Cada hora";
 "settings.notifications.actionReminder.frequency.other" = "Cada %lld horas";
 "settings.notifications.actionReminder.disabled" = "Los recordatorios están desactivados para esta acción.";
-"settings.notifications.actionReminder.preview" = "Vista previa";
-"settings.notifications.actionReminder.previewUnavailable" = "Aún no hay ningún recordatorio programado. Registra esta acción para programar uno.";
 "settings.about.section" = "Acerca de";
 "settings.about.appVersion" = "Versión de la app";
 "settings.title" = "Configuración";


### PR DESCRIPTION
## Summary
- remove the preview control from action reminders in the settings view
- delete the unused reminder preview localization entries across all supported languages

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e51ae16d708320ad04df3a37eaa479