### PR TITLE
Adjust last action duration layout

### DIFF
--- a/babynanny/HomeView.swift
+++ b/babynanny/HomeView.swift
@@ -220,9 +220,21 @@ private struct ActionCard: View {
                                 .font(.subheadline)
                                 .foregroundStyle(.secondary)
                         } else if let lastCompleted {
-                            Text(lastCompleted.detailDescription)
-                                .font(.subheadline)
-                                .foregroundStyle(.secondary)
+                            ZStack {
+                                HStack(alignment: .firstTextBaseline) {
+                                    Text(lastCompleted.detailDescription)
+                                        .font(.subheadline)
+                                        .foregroundStyle(.secondary)
+
+                                    Spacer()
+                                }
+
+                                Text(lastCompleted.durationDescription())
+                                    .font(.caption2)
+                                    .foregroundStyle(.secondary)
+                                    .monospacedDigit()
+                                    .frame(maxWidth: .infinity, alignment: .center)
+                            }
                         } else {
                             Text(L10n.Home.noEntries)
                                 .font(.subheadline)
@@ -259,9 +271,7 @@ private struct ActionCard: View {
                 if let lastCompleted {
                     let timestampDescription = lastCompleted.endDateTimeDescription()
                         ?? lastCompleted.startDateTimeDescription()
-                    let durationDescription = lastCompleted.durationDescription()
-
-                    Text(L10n.Home.lastRunWithDuration(timestampDescription, durationDescription))
+                    Text(L10n.Home.lastRun(timestampDescription))
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }


### PR DESCRIPTION
## Summary
- center the last action duration within the home action cards and reduce its size for clearer hierarchy
- keep the last run timestamp while avoiding duplicate duration text

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e51ce999788320bd561a570620ad67