### PR TITLE
Fix overlapping duration text on HomeView

### DIFF
--- a/babynanny/HomeView.swift
+++ b/babynanny/HomeView.swift
@@ -220,21 +220,9 @@ private struct ActionCard: View {
                                 .font(.subheadline)
                                 .foregroundStyle(.secondary)
                         } else if let lastCompleted {
-                            ZStack {
-                                HStack(alignment: .firstTextBaseline) {
-                                    Text(lastCompleted.detailDescription)
-                                        .font(.subheadline)
-                                        .foregroundStyle(.secondary)
-
-                                    Spacer()
-                                }
-
-                                Text(lastCompleted.durationDescription())
-                                    .font(.caption2)
-                                    .foregroundStyle(.secondary)
-                                    .monospacedDigit()
-                                    .frame(maxWidth: .infinity, alignment: .center)
-                            }
+                            Text(lastCompleted.detailDescription)
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
                         } else {
                             Text(L10n.Home.noEntries)
                                 .font(.subheadline)
@@ -269,11 +257,19 @@ private struct ActionCard: View {
 
             } else {
                 if let lastCompleted {
-                    let timestampDescription = lastCompleted.endDateTimeDescription()
-                        ?? lastCompleted.startDateTimeDescription()
-                    Text(L10n.Home.lastRun(timestampDescription))
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                    if let timestampDescription = lastCompleted.endDateTimeDescription()
+                        ?? lastCompleted.startDateTimeDescription() {
+                        HStack(alignment: .firstTextBaseline, spacing: 8) {
+                            Text(L10n.Home.lastRun(timestampDescription))
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+
+                            Text(lastCompleted.durationDescription())
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                                .monospacedDigit()
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- prevent action subtype and duration text from overlapping on the home action cards
- show the duration alongside the last run timestamp and increase its font size for clarity

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e51f91c2988320bba1e71d843423e3