### PR TITLE
Fix optional binding for last completed timestamp

### DIFF
--- a/babynanny/HomeView.swift
+++ b/babynanny/HomeView.swift
@@ -257,18 +257,18 @@ private struct ActionCard: View {
 
             } else {
                 if let lastCompleted {
-                    if let timestampDescription = lastCompleted.endDateTimeDescription()
-                        ?? lastCompleted.startDateTimeDescription() {
-                        HStack(alignment: .firstTextBaseline, spacing: 8) {
-                            Text(L10n.Home.lastRun(timestampDescription))
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
+                    let timestampDescription = lastCompleted.endDateTimeDescription()
+                        ?? lastCompleted.startDateTimeDescription()
 
-                            Text(lastCompleted.durationDescription())
-                                .font(.footnote)
-                                .foregroundStyle(.secondary)
-                                .monospacedDigit()
-                        }
+                    HStack(alignment: .firstTextBaseline, spacing: 8) {
+                        Text(L10n.Home.lastRun(timestampDescription))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+
+                        Text(lastCompleted.durationDescription())
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                            .monospacedDigit()
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- remove the invalid optional binding around the last completed action timestamp in `ActionCard`
- use a simple constant to display the timestamp string to restore compilation

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e523dea21483209457a8cb724b0fca