### PR TITLE
Hide next reminder status without scheduled notifications

### DIFF
--- a/babynanny/SettingsView.swift
+++ b/babynanny/SettingsView.swift
@@ -313,24 +313,26 @@ private extension SettingsView {
 
     @ViewBuilder
     private func actionReminderStatus(for category: BabyActionCategory, isEnabled: Bool) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text(L10n.Settings.nextReminderLabel)
+        if isEnabled == false {
+            Text(L10n.Settings.actionReminderDisabled)
                 .font(.footnote)
-                .fontWeight(.semibold)
-
-            if isEnabled == false {
-                Text(L10n.Settings.actionReminderDisabled)
+                .foregroundStyle(.secondary)
+                .padding(.vertical, 4)
+        } else if isLoadingActionReminders {
+            HStack(spacing: 8) {
+                ProgressView()
+                    .progressViewStyle(CircularProgressViewStyle())
+                Text(L10n.Settings.nextReminderLoading)
                     .font(.footnote)
                     .foregroundStyle(.secondary)
-            } else if isLoadingActionReminders {
-                HStack(spacing: 8) {
-                    ProgressView()
-                        .progressViewStyle(CircularProgressViewStyle())
-                    Text(L10n.Settings.nextReminderLoading)
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
-                }
-            } else if let summary = actionReminderSummaries[category] {
+            }
+            .padding(.vertical, 4)
+        } else if let summary = actionReminderSummaries[category] {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(L10n.Settings.nextReminderLabel)
+                    .font(.footnote)
+                    .fontWeight(.semibold)
+
                 Text(
                     L10n.Settings.nextReminderScheduled(
                         summary.fireDate.formatted(date: .abbreviated, time: .shortened),
@@ -339,13 +341,9 @@ private extension SettingsView {
                 )
                 .font(.footnote)
                 .foregroundStyle(.secondary)
-            } else {
-                Text(L10n.Settings.nextReminderUnavailable)
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
             }
+            .padding(.vertical, 4)
         }
-        .padding(.vertical, 4)
     }
 
 }


### PR DESCRIPTION
## Summary
- show the action reminder status label only when a scheduled notification summary is available
- keep disabled and loading states without displaying placeholder "next reminder" messaging

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e563c4a21883208b42a3435ff86490